### PR TITLE
Fix regex pattern for measure extraction

### DIFF
--- a/src/tmdl_format_measures/sorting.py
+++ b/src/tmdl_format_measures/sorting.py
@@ -4,7 +4,7 @@ from re import search as re_search
 from typing import List
 
 MEASURE_REGEX = re_compile(
-    r"(\s+measure\s.*?lineageTag: .+?(?:\n\s*annotation PBI_FormatHint = .+?)?\n)",
+    r"((?:\s+///[^\n]*\n)*\s+measure\s.*?lineageTag: .+?(?:\n\s*annotation PBI_FormatHint = .+?)?\n)",
     DOTALL,
 )
 


### PR DESCRIPTION
Fix: keep /// doc comments anchored to their measure when sorting